### PR TITLE
feat: add design documentation for Results & Payouts Page

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -1,0 +1,11 @@
+# Results & Payouts Page
+
+This design covers the Results & Payouts Page for Predictify, including:
+
+- Past bets list (event name, bet amount, outcome)
+- Winning bet highlights and payout display
+- Platform fee deductions
+- Withdraw winnings button
+- Dark theme with clean layout
+
+👉 [View the design in Figma](https://www.figma.com/design/MniUXvhhw8zByH1tTF416Q/Predictify?node-id=1-2&t=5srcb0bfBWs0Xdmn-1)


### PR DESCRIPTION
Closes: #6

# Results & Payouts Page

This design covers the Results & Payouts Page for Predictify, including:

- Past bets list (event name, bet amount, outcome)
- Winning bet highlights and payout display
- Platform fee deductions
- Withdraw winnings button
- Dark theme with clean layout

👉 [View the design in Figma](https://www.figma.com/design/MniUXvhhw8zByH1tTF416Q/Predictify?node-id=1-2&t=5srcb0bfBWs0Xdmn-1)