### PR TITLE
Design/sticky action panel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,6 +60,7 @@ Related to #[issue-number]
 - [ ] Focus-visible screenshot for the primary interactive element (required when focus behavior changed)
 - [ ] Open overlay screenshot for modal, drawer, popover, select, or date picker (required when applicable)
 - [ ] Quick actions closed and open states (required for toolbar, FAB, or bottom-sheet action changes)
+- [ ] Keyboard-open mobile screenshot and desktop sticky state (required for sticky action panel changes)
 
 ### Before
 <!-- Screenshot of the current state -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,29 @@
-# 🚀 Pull Request
+# Pull Request
 
-## 📝 Description
+## Description
 <!-- Provide a brief description of what this PR accomplishes -->
 
-## 🎯 Type of Change
+## Type of Change
 <!-- Mark the appropriate option(s) with an 'x' -->
 
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] ✨ New feature (non-breaking change which adds functionality)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📚 Documentation update
-- [ ] ⚡ Performance improvement
-- [ ] 🔧 Refactoring (no functional changes)
-- [ ] 🎨 Style/UI changes
-- [ ] 🧪 Test updates
-- [ ] 🔄 CI/CD changes
-- [ ] 🔒 Security improvements
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Refactoring (no functional changes)
+- [ ] Style/UI changes
+- [ ] Test updates
+- [ ] CI/CD changes
+- [ ] Security improvements
 
-## 🔗 Related Issues
+## Related Issues
 <!-- Link to related issues using keywords like "Closes", "Fixes", "Resolves" -->
 
 Closes #[issue-number]
 Related to #[issue-number]
 
-## 📋 Changes Made
+## Changes Made
 <!-- Provide a detailed list of changes made -->
 
 ### Files Modified
@@ -34,24 +34,31 @@ Related to #[issue-number]
 - [Describe the main changes and their impact]
 - [Include any architectural decisions made]
 
-## 🧪 Testing
+## Testing
 <!-- Describe how you tested your changes -->
 
-- [ ] ✅ Unit tests added/updated
-- [ ] ✅ Integration tests added/updated
-- [ ] ✅ Manual testing completed
-- [ ] ✅ Cross-browser testing (if applicable)
-- [ ] ✅ Mobile responsiveness tested (if applicable)
-- [ ] ✅ Accessibility testing completed
-- [ ] ✅ Performance testing (if applicable)
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing completed
+- [ ] Cross-browser testing (if applicable)
+- [ ] Mobile responsiveness tested (if applicable)
+- [ ] Accessibility testing completed
+- [ ] Performance testing (if applicable)
 
 ### Test Coverage
 - [ ] New code is covered by tests
 - [ ] Existing tests still pass
 - [ ] Test coverage meets project standards
 
-## 📸 Screenshots/Videos
+## Screenshots/Videos
 <!-- Add screenshots or videos showing the changes (if applicable) -->
+
+### Minimum screenshots for UI/design PRs
+- [ ] Desktop default state
+- [ ] Mobile default state
+- [ ] One stressed state: error, empty, loading, success, validation, open menu, or open modal
+- [ ] Focus-visible screenshot for the primary interactive element (required when focus behavior changed)
+- [ ] Open overlay screenshot for modal, drawer, popover, select, or date picker (required when applicable)
 
 ### Before
 <!-- Screenshot of the current state -->
@@ -59,36 +66,36 @@ Related to #[issue-number]
 ### After
 <!-- Screenshot of the new state -->
 
-## ✅ Pre-submission Checklist
+## Pre-submission Checklist
 <!-- Complete all items before submitting -->
 
 ### Code Quality
-- [ ] ✅ Code follows project style guidelines
-- [ ] ✅ Self-review completed
-- [ ] ✅ Code is self-documenting
-- [ ] ✅ No console errors or warnings
-- [ ] ✅ No linting errors
-- [ ] ✅ No TypeScript errors (if applicable)
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Code is self-documenting
+- [ ] No console errors or warnings
+- [ ] No linting errors
+- [ ] No TypeScript errors (if applicable)
 
 ### Functionality
-- [ ] ✅ All tests pass
-- [ ] ✅ Feature works as expected
-- [ ] ✅ No breaking changes introduced
-- [ ] ✅ Performance impact assessed
+- [ ] All tests pass
+- [ ] Feature works as expected
+- [ ] No breaking changes introduced
+- [ ] Performance impact assessed
 
 ### Documentation
-- [ ] ✅ README updated (if applicable)
-- [ ] ✅ Code comments added where necessary
-- [ ] ✅ API documentation updated (if applicable)
-- [ ] ✅ Changelog updated (if applicable)
+- [ ] README updated (if applicable)
+- [ ] Code comments added where necessary
+- [ ] API documentation updated (if applicable)
+- [ ] Changelog updated (if applicable)
 
 ### Security & Accessibility
-- [ ] ✅ Security considerations addressed
-- [ ] ✅ Accessibility standards met
-- [ ] ✅ No sensitive data exposed
-- [ ] ✅ Input validation implemented
+- [ ] Security considerations addressed
+- [ ] Accessibility standards met
+- [ ] No sensitive data exposed
+- [ ] Input validation implemented
 
-## ⚠️ Breaking Changes
+## Breaking Changes
 <!-- Describe any breaking changes and migration steps -->
 
 **Breaking Changes:**
@@ -97,7 +104,7 @@ Related to #[issue-number]
 **Migration Steps:**
 - [Provide steps for users to migrate]
 
-## 🔧 Additional Notes
+## Additional Notes
 <!-- Any other information that reviewers should know -->
 
 ### Dependencies
@@ -117,7 +124,7 @@ Related to #[issue-number]
 - [ ] Tested on Edge
 - [ ] Tested on mobile devices
 
-## 🏷️ Labels
+## Labels
 <!-- Add appropriate labels for this PR -->
 
 - `feature` - for new features
@@ -129,7 +136,7 @@ Related to #[issue-number]
 - `backend` - for backend changes
 - `ui/ux` - for design changes
 
-## 👥 Reviewers
+## Reviewers
 <!-- Tag relevant team members for review -->
 
 - [ ] Frontend team review
@@ -139,4 +146,4 @@ Related to #[issue-number]
 
 ---
 
-**Note:** Please ensure all checkboxes are completed before submitting this PR. This helps maintain code quality and speeds up the review process. 
+**Note:** Please ensure all checkboxes are completed before submitting this PR. This helps maintain code quality and speeds up the review process.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -59,6 +59,7 @@ Related to #[issue-number]
 - [ ] One stressed state: error, empty, loading, success, validation, open menu, or open modal
 - [ ] Focus-visible screenshot for the primary interactive element (required when focus behavior changed)
 - [ ] Open overlay screenshot for modal, drawer, popover, select, or date picker (required when applicable)
+- [ ] Quick actions closed and open states (required for toolbar, FAB, or bottom-sheet action changes)
 
 ### Before
 <!-- Screenshot of the current state -->

--- a/DESIGN_ACCESSIBILITY_CHECKLIST.md
+++ b/DESIGN_ACCESSIBILITY_CHECKLIST.md
@@ -12,103 +12,106 @@ Timeframe: apply this checklist to any screen touched in the last 96 hours befor
 - Check one normal state and one stressed state such as empty, error, loading, or success.
 - Compare the PR screenshots against the checklist below instead of relying on memory.
 
-## 1. Screen Frame And Navigation
+## Screen Shells And Navigation
 
 - [ ] The page has one clear screen title that matches the main task.
-- [ ] Landmark content is visually grouped so users can tell header, body, side panel, and footer apart.
-- [ ] Repeated navigation does not visually overpower the primary task.
-- [ ] Sticky headers, drawers, modals, and sheets do not cover the focused element or critical messaging.
-- [ ] Dense dashboards still preserve a readable scan order from top-left to bottom-right.
+- [ ] Header, body, side panel, and footer regions are visually distinct enough to scan quickly.
+- [ ] Repeated navigation does not overpower the primary task area.
+- [ ] Sticky headers, floating bars, and side panels do not cover focused elements or critical messaging.
+- [ ] Dense layouts still preserve a readable scan order from top-left to bottom-right.
+- [ ] Keyboard focus moves through navigation and page content in a predictable order.
+- [ ] Focus remains visible when drawers, sheets, and route transitions appear.
+- [ ] Motion used in page transitions or sticky navigation does not distract from task completion.
 
-Passing pattern: a settings screen shows one page title, grouped cards with clear section headings, and sticky controls that do not cover active fields.
+Passing pattern: a dashboard has one page title, a clear primary content region, and sticky controls that never cover active fields.
 
-Failing pattern: a modal opens over the page but hides the confirmation button or page-level error banner behind it.
+Failing pattern: a floating header hides the focused field, or a drawer opens and focus jumps behind the active panel.
 
-## 2. Text And Contrast
-
-- [ ] Body text, labels, helper text, and badges remain readable against their background in all supported themes.
-- [ ] Muted text is still readable for essential information such as deadlines, helper copy, and table metadata.
-- [ ] Status colors are supported by text or icon meaning and not color alone.
-- [ ] Disabled controls are still legible enough to explain what is unavailable.
-- [ ] Placeholder text is never the only place where critical instructions live.
-
-Passing pattern: "3 high priority disputes" uses an icon plus text, and helper text is still readable without zooming.
-
-Failing pattern: an error is shown only by red border color, or a low-contrast gray label disappears on card backgrounds.
-
-## 3. Forms, Labels, And Instructions
+## Forms And Authentication Screens
 
 - [ ] Every input, select, switch, checkbox, radio group, date picker, and textarea has a visible label.
 - [ ] Required fields are identified consistently and do not rely on placeholder text alone.
-- [ ] Helper text appears next to the field it explains, not in a separate paragraph far away.
-- [ ] Compound controls such as option builders, filter bars, and date pickers include enough visible context to understand the expected value.
-- [ ] Icon-only buttons inside forms have an adjacent text label, tooltip, or visible group heading that explains the action.
-
-Passing pattern: "Platform Fee (%)" has a visible label, a numeric input, and helper text directly below describing the allowed range.
-
-Failing pattern: an "Add" icon button appears next to an input with no nearby text clarifying whether it adds a row, saves the value, or opens a picker.
-
-## 4. Errors, Validation, And Status Messaging
-
-- [ ] Validation messages say what went wrong and what to do next.
-- [ ] Error copy is placed near the affected field or task, not only in a global toast.
-- [ ] Success, warning, and destructive states use distinct language and visual treatment.
-- [ ] Time-sensitive actions explain deadlines, retries, or irreversible outcomes in plain language.
-- [ ] Empty, loading, and no-results states still guide the next action.
-
-Passing pattern: "Invalid email or password" appears above the login form, and a field-level message explains missing required data when relevant.
-
-Failing pattern: a save action closes the form with no visible success feedback, or a destructive state uses the same styling as an informational note.
-
-## 5. Interactive Controls And Focus
-
-- [ ] Every interactive element has a visible focus state that stands out from hover and selected states.
-- [ ] Focus order follows the visual layout and does not jump into hidden panels or disabled controls.
-- [ ] Tabs, accordions, drawers, and popovers show which item is active and which item currently has keyboard focus.
-- [ ] Click targets are large enough for touch use, especially icon buttons, switches, pagination, and row actions.
-- [ ] Keyboard users can reach all primary actions without getting trapped in widgets.
-
-Passing pattern: tabbing through a new-event form moves from title to description to category to deadline to visibility controls in a predictable order.
-
-Failing pattern: focus disappears on a ghost icon button, or tab focus enters a hidden tab panel before the visible Save button.
-
-## 6. Motion And State Changes
-
-- [ ] Animation supports understanding and does not delay task completion.
-- [ ] Important content does not slide, pulse, or autoplay in a way that competes with form entry.
-- [ ] Loading states preserve layout so content does not jump when data appears.
-- [ ] Hover-only motion is not required to discover actions.
-- [ ] Reduced-motion behavior is defined for page transitions, chart animation, counters, and decorative backgrounds.
-
-Passing pattern: a loading skeleton holds card height in place and the final content fades in without shifting buttons away from the pointer.
-
-Failing pattern: success banners auto-dismiss before the user can read them, or animated counters rapidly change values with no reduced-motion fallback.
-
-## Component-Type Spot Checks
-
-### Forms And Authentication Screens
-
 - [ ] Labels remain visible while typing.
-- [ ] Password, OTP, and email fields expose errors near the field and at form level when needed.
-- [ ] Secondary actions such as "Forgot password?" remain visually subordinate to the primary submit action.
+- [ ] Helper text appears next to the field it explains, not in a separate paragraph far away.
+- [ ] Placeholder text is never the only place where critical instructions live.
+- [ ] Validation messages say what went wrong and what to do next.
+- [ ] Error copy appears near the affected field or form, not only in a toast.
+- [ ] Success and destructive states are visually distinct and not color-only.
+- [ ] The main submit path is reachable and understandable by keyboard users.
+- [ ] Focus states stand out from hover and selected states on every field and button.
+- [ ] Password, OTP, and email entry flows show clear state changes without excessive motion.
 
-### Data-Dense Dashboard Screens
+Passing pattern: a login screen shows visible labels, an inline error message, and a clear primary submit button with visible focus.
 
-- [ ] KPI cards, charts, and status rows have readable labels and do not rely on color-only meaning.
-- [ ] Badge, icon, and trend treatments remain understandable for color-blind users.
-- [ ] Table or card actions are discoverable by keyboard and touch, not just hover.
+Failing pattern: an input depends on placeholder text for context, or an invalid state is shown only with a red border.
 
-### Settings, Preferences, And Admin Panels
+## Settings, Preferences, And Admin Panels
 
+- [ ] Grouped controls use headings, cards, or separators that make the hierarchy obvious.
 - [ ] Switches clearly describe what turns on or off and what changes immediately.
-- [ ] Grouped controls use headings or separators that make the hierarchy obvious.
-- [ ] Success and error feedback remains visible long enough to review.
+- [ ] Helper text for toggles, thresholds, and policy settings remains readable against the background.
+- [ ] Tabbed settings views show both the active tab and the currently focused tab trigger clearly.
+- [ ] Success, warning, and error feedback stays visible long enough to review.
+- [ ] High-impact settings explain deadlines, irreversible outcomes, or retry steps in plain language.
+- [ ] Save, cancel, and destructive actions are visually distinct from each other.
+- [ ] Dense admin controls still provide touch-friendly hit areas for buttons, switches, and row actions.
+- [ ] Auto-updating banners, counters, or status chips do not animate in ways that interrupt form entry.
 
-### Overlays, Popovers, Drawers, And Modals
+Passing pattern: a settings screen groups platform, security, and notification controls into clear sections with readable helper text and durable save feedback.
+
+Failing pattern: all controls appear in one undifferentiated block, or a success message disappears before a reviewer can read it.
+
+## Data Views, Dashboards, And Reporting Screens
+
+- [ ] KPI cards, charts, badges, and status rows remain readable against their backgrounds.
+- [ ] Trend, warning, and success states are understandable without relying on color alone.
+- [ ] Muted metadata such as date ranges, counts, and deadlines remains readable.
+- [ ] Card actions, pagination, and row-level controls are discoverable by keyboard and touch, not just hover.
+- [ ] Charts, placeholders, and loading states preserve layout so content does not jump when data appears.
+- [ ] Focus order follows the visual order across cards, tabs, filters, and actions.
+- [ ] Empty, loading, and no-results states guide the next action instead of leaving dead ends.
+- [ ] Decorative count-up or chart animations support comprehension and have a reduced-motion fallback.
+
+Passing pattern: a KPI grid uses text plus icon meaning, readable metadata, and stable loading placeholders that do not shift buttons.
+
+Failing pattern: a chart uses color as the only meaning cue, or row actions appear only on hover with no visible keyboard path.
+
+## Overlays, Popovers, Drawers, Modals, And Pickers
 
 - [ ] The trigger, title, body, and primary action are all visible without accidental clipping.
 - [ ] Focus stays inside the active overlay until it is dismissed.
-- [ ] Background content is visually de-emphasized but still stable when the overlay closes.
+- [ ] Opening an overlay moves focus to a logical starting point inside it.
+- [ ] Closing an overlay returns focus to a sensible trigger or nearby control.
+- [ ] Popovers, selects, date pickers, and menus do not render off-screen on desktop or mobile.
+- [ ] Background content is visually de-emphasized but remains stable when the overlay closes.
+- [ ] Focus states remain visible on icon-only controls and compact menu items.
+- [ ] Motion used for opening and closing overlays does not block the user from acting quickly.
+
+Passing pattern: a date picker opens aligned to its trigger, keeps focus within the popover, and closes back to the trigger without layout shift.
+
+Failing pattern: a modal clips the primary action below the fold, or focus escapes into the page behind it.
+
+## Lists, Tables, Filters, And Option Builders
+
+- [ ] Filter controls have visible labels or nearby headings that explain what they change.
+- [ ] Icon-only add, remove, copy, or clear actions have enough visible context to make the action obvious.
+- [ ] Rows, cards, and option groups preserve readable spacing and touch-friendly targets.
+- [ ] Repeated actions such as remove, reorder, and expand show visible focus and active states.
+- [ ] Validation for dynamic rows explains which row failed and what to fix.
+- [ ] Empty rows, loading rows, and no-results states still guide the next action.
+- [ ] Animated insertion, removal, or reordering does not disrupt orientation or cause focus loss.
+
+Passing pattern: a dynamic option builder labels the group, gives each row a predictable focus path, and keeps add/remove controls understandable.
+
+Failing pattern: a trash icon appears with no visible context, or inserting a row causes focus to disappear.
+
+## Cross-Screen Accessibility Checks
+
+- [ ] Body text, labels, helper text, and badges remain readable in all supported themes.
+- [ ] Disabled controls stay legible enough to explain what is unavailable.
+- [ ] Click and tap targets are large enough for frequent actions, especially icon buttons and compact controls.
+- [ ] Hover-only behavior is never required to discover a critical action.
+- [ ] Reduced-motion behavior is defined for page transitions, counters, charts, decorative backgrounds, and overlays.
 
 ## Minimum Screenshots Required In PR Review
 
@@ -129,17 +132,17 @@ Use these checks as examples during review.
 
 ### `app/(auth)/login`
 
-- Pass: visible labels for email and password, inline destructive alert for failed login, clear primary action.
-- Risk to watch: the alert is page-level only, so field-specific validation should not be added later without nearby messaging.
+- Pass: visible labels for email and password, inline destructive alert for failed login, clear primary action, and a short keyboard path.
+- Risk to watch: the alert is page-level only, so future field-specific validation should not be added without nearby messaging.
 
 ### `app/(dashboard)/settings`
 
-- Pass: most inputs and switches have visible labels and helper text, sections are grouped with headings and separators.
+- Pass: most inputs and switches have visible labels and helper text, sections are grouped with headings and separators, and the screen maps well to the settings/admin checklist.
 - Risk to watch: success feedback auto-clears after 3 seconds, which is easy to miss for slower readers.
 - Risk to watch: tabbed settings UIs need visible focus treatment and clear active-state contrast during review.
 
 ### `app/(dashboard)/events/new`
 
-- Pass: main fields are labeled, preview helps confirm content before submit, primary and secondary actions are separated.
+- Pass: main fields are labeled, preview helps confirm content before submit, and primary and secondary actions are separated.
 - Risk to watch: icon-only add and remove buttons need strong visible focus and clear accessible intent in design review.
-- Risk to watch: deadline picker, category select, and dynamic option rows should be checked for keyboard order and overlay clipping.
+- Risk to watch: deadline picker, category select, and dynamic option rows should be checked against the overlay and option-builder sections for keyboard order and clipping.

--- a/DESIGN_ACCESSIBILITY_CHECKLIST.md
+++ b/DESIGN_ACCESSIBILITY_CHECKLIST.md
@@ -1,0 +1,145 @@
+# Screen Accessibility Checklist
+
+Use this checklist during design review and PR review for any frontend screen change. The goal is to catch screen-level regressions quickly before they reach QA.
+
+Scope: frontend design only.
+Timeframe: apply this checklist to any screen touched in the last 96 hours before merging.
+
+## How To Review
+
+- Review the changed screen at desktop and mobile widths.
+- Tab through the main interactive path once with a keyboard.
+- Check one normal state and one stressed state such as empty, error, loading, or success.
+- Compare the PR screenshots against the checklist below instead of relying on memory.
+
+## 1. Screen Frame And Navigation
+
+- [ ] The page has one clear screen title that matches the main task.
+- [ ] Landmark content is visually grouped so users can tell header, body, side panel, and footer apart.
+- [ ] Repeated navigation does not visually overpower the primary task.
+- [ ] Sticky headers, drawers, modals, and sheets do not cover the focused element or critical messaging.
+- [ ] Dense dashboards still preserve a readable scan order from top-left to bottom-right.
+
+Passing pattern: a settings screen shows one page title, grouped cards with clear section headings, and sticky controls that do not cover active fields.
+
+Failing pattern: a modal opens over the page but hides the confirmation button or page-level error banner behind it.
+
+## 2. Text And Contrast
+
+- [ ] Body text, labels, helper text, and badges remain readable against their background in all supported themes.
+- [ ] Muted text is still readable for essential information such as deadlines, helper copy, and table metadata.
+- [ ] Status colors are supported by text or icon meaning and not color alone.
+- [ ] Disabled controls are still legible enough to explain what is unavailable.
+- [ ] Placeholder text is never the only place where critical instructions live.
+
+Passing pattern: "3 high priority disputes" uses an icon plus text, and helper text is still readable without zooming.
+
+Failing pattern: an error is shown only by red border color, or a low-contrast gray label disappears on card backgrounds.
+
+## 3. Forms, Labels, And Instructions
+
+- [ ] Every input, select, switch, checkbox, radio group, date picker, and textarea has a visible label.
+- [ ] Required fields are identified consistently and do not rely on placeholder text alone.
+- [ ] Helper text appears next to the field it explains, not in a separate paragraph far away.
+- [ ] Compound controls such as option builders, filter bars, and date pickers include enough visible context to understand the expected value.
+- [ ] Icon-only buttons inside forms have an adjacent text label, tooltip, or visible group heading that explains the action.
+
+Passing pattern: "Platform Fee (%)" has a visible label, a numeric input, and helper text directly below describing the allowed range.
+
+Failing pattern: an "Add" icon button appears next to an input with no nearby text clarifying whether it adds a row, saves the value, or opens a picker.
+
+## 4. Errors, Validation, And Status Messaging
+
+- [ ] Validation messages say what went wrong and what to do next.
+- [ ] Error copy is placed near the affected field or task, not only in a global toast.
+- [ ] Success, warning, and destructive states use distinct language and visual treatment.
+- [ ] Time-sensitive actions explain deadlines, retries, or irreversible outcomes in plain language.
+- [ ] Empty, loading, and no-results states still guide the next action.
+
+Passing pattern: "Invalid email or password" appears above the login form, and a field-level message explains missing required data when relevant.
+
+Failing pattern: a save action closes the form with no visible success feedback, or a destructive state uses the same styling as an informational note.
+
+## 5. Interactive Controls And Focus
+
+- [ ] Every interactive element has a visible focus state that stands out from hover and selected states.
+- [ ] Focus order follows the visual layout and does not jump into hidden panels or disabled controls.
+- [ ] Tabs, accordions, drawers, and popovers show which item is active and which item currently has keyboard focus.
+- [ ] Click targets are large enough for touch use, especially icon buttons, switches, pagination, and row actions.
+- [ ] Keyboard users can reach all primary actions without getting trapped in widgets.
+
+Passing pattern: tabbing through a new-event form moves from title to description to category to deadline to visibility controls in a predictable order.
+
+Failing pattern: focus disappears on a ghost icon button, or tab focus enters a hidden tab panel before the visible Save button.
+
+## 6. Motion And State Changes
+
+- [ ] Animation supports understanding and does not delay task completion.
+- [ ] Important content does not slide, pulse, or autoplay in a way that competes with form entry.
+- [ ] Loading states preserve layout so content does not jump when data appears.
+- [ ] Hover-only motion is not required to discover actions.
+- [ ] Reduced-motion behavior is defined for page transitions, chart animation, counters, and decorative backgrounds.
+
+Passing pattern: a loading skeleton holds card height in place and the final content fades in without shifting buttons away from the pointer.
+
+Failing pattern: success banners auto-dismiss before the user can read them, or animated counters rapidly change values with no reduced-motion fallback.
+
+## Component-Type Spot Checks
+
+### Forms And Authentication Screens
+
+- [ ] Labels remain visible while typing.
+- [ ] Password, OTP, and email fields expose errors near the field and at form level when needed.
+- [ ] Secondary actions such as "Forgot password?" remain visually subordinate to the primary submit action.
+
+### Data-Dense Dashboard Screens
+
+- [ ] KPI cards, charts, and status rows have readable labels and do not rely on color-only meaning.
+- [ ] Badge, icon, and trend treatments remain understandable for color-blind users.
+- [ ] Table or card actions are discoverable by keyboard and touch, not just hover.
+
+### Settings, Preferences, And Admin Panels
+
+- [ ] Switches clearly describe what turns on or off and what changes immediately.
+- [ ] Grouped controls use headings or separators that make the hierarchy obvious.
+- [ ] Success and error feedback remains visible long enough to review.
+
+### Overlays, Popovers, Drawers, And Modals
+
+- [ ] The trigger, title, body, and primary action are all visible without accidental clipping.
+- [ ] Focus stays inside the active overlay until it is dismissed.
+- [ ] Background content is visually de-emphasized but still stable when the overlay closes.
+
+## Minimum Screenshots Required In PR Review
+
+For any design or UI PR, include at least these screenshots in the PR description:
+
+- 1 desktop screenshot of the changed screen in its default state.
+- 1 mobile screenshot of the same screen or flow.
+- 1 screenshot of a stressed state: error, empty, loading, success, validation, open menu, or open modal.
+
+If the PR changes focus behavior, overlays, or motion, also include:
+
+- 1 screenshot showing keyboard focus visibility on the primary interactive element.
+- 1 screenshot of any modal, drawer, popover, select, or date picker while open.
+
+## Validation Against Existing Screens
+
+Use these checks as examples during review.
+
+### `app/(auth)/login`
+
+- Pass: visible labels for email and password, inline destructive alert for failed login, clear primary action.
+- Risk to watch: the alert is page-level only, so field-specific validation should not be added later without nearby messaging.
+
+### `app/(dashboard)/settings`
+
+- Pass: most inputs and switches have visible labels and helper text, sections are grouped with headings and separators.
+- Risk to watch: success feedback auto-clears after 3 seconds, which is easy to miss for slower readers.
+- Risk to watch: tabbed settings UIs need visible focus treatment and clear active-state contrast during review.
+
+### `app/(dashboard)/events/new`
+
+- Pass: main fields are labeled, preview helps confirm content before submit, primary and secondary actions are separated.
+- Risk to watch: icon-only add and remove buttons need strong visible focus and clear accessible intent in design review.
+- Risk to watch: deadline picker, category select, and dynamic option rows should be checked for keyboard order and overlay clipping.

--- a/DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md
+++ b/DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md
@@ -1,0 +1,188 @@
+# Mobile Portfolio Quick Actions
+
+This design spec defines how quick actions should work on mobile portfolio screens such as My Predictions, claimable positions, and transaction history.
+
+Scope: frontend design only.
+Timeframe: apply this pattern to mobile portfolio work delivered within 96 hours before merge.
+
+## Goal
+
+Keep high-frequency actions within thumb reach without overcrowding the portfolio screen. Quick actions should feel easy to access, but `Claim all` must never be easy to trigger by accident.
+
+## Preferred Placement Pattern
+
+Use a two-layer mobile action model:
+
+- Closed state: a sticky bottom quick-actions bar anchored inside the safe area.
+- Open state: a bottom sheet for secondary controls and batch actions.
+
+Do not use a floating action button as the primary pattern for portfolio actions. A FAB hides action labels, competes with list content, and makes `Claim all` feel too immediate for a high-impact action.
+
+### Closed State
+
+The sticky bottom bar should stay within thumb reach and expose only the most common actions:
+
+- Search
+- Filter
+- Group
+- Claim all, only when claimable positions exist
+
+Rules:
+
+- Keep labels visible. Do not rely on icon-only controls for primary portfolio actions.
+- Limit the closed bar to 3 visible controls plus one overflow trigger if needed.
+- If `Claim all` is available, place it at the far right as the most deliberate action.
+- If `Claim all` is not available, do not show a disabled primary button. Replace it with more useful space for search, filter, or group.
+- Keep the bar persistent while scrolling, but never let it cover the last card, last row action, or bottom-sheet handle.
+
+Passing pattern: a mobile portfolio shows Search, Filter, Group, and a clearly labeled `Claim all` button in a bottom bar that sits above the safe area.
+
+Failing pattern: a floating action button opens unlabeled actions, or `Claim all` appears as a prominent always-enabled control even when nothing is claimable.
+
+### Open State
+
+Opening quick actions should reveal a bottom sheet rather than a full-screen takeover.
+
+The sheet should contain:
+
+- Search field at the top
+- Filter chips or grouped filter options
+- Group options such as status, market, token, or claimability
+- Portfolio summary row when useful, such as `12 claimable positions`
+- `Claim all` action block when claimable positions exist
+
+Rules:
+
+- Keep the first interactive controls above the fold on common mobile heights.
+- Preserve the underlying portfolio context so the user understands what the sheet is changing.
+- Use clear section labels so search, filter, group, and claim actions do not blend together.
+- Show active filter count and active grouping in the sheet header or trigger row.
+
+Passing pattern: the bottom sheet opens to a search field, grouped filter controls, and a separate claim section with summary text.
+
+Failing pattern: all controls are merged into one long list with no hierarchy, or the sheet opens so tall that the user loses context.
+
+## Action Hierarchy
+
+Order actions by frequency and risk:
+
+1. Search
+2. Filter
+3. Group
+4. Claim all
+
+Design implications:
+
+- Search, filter, and group should be reachable in one tap from the closed state.
+- `Claim all` should be reachable, but visually separated from discovery actions.
+- Do not style `Claim all` like a destructive action, but do style it as high impact.
+- Avoid placing `Claim all` next to close, back, or dismiss controls.
+
+## Confirmation Rules For High-Impact Actions
+
+`Claim all` requires a confirmation step every time.
+
+Use a confirmation bottom sheet or confirmation dialog with:
+
+- The number of claimable positions
+- Estimated total claim amount by token if available
+- Any fee, gas, or settlement note that changes user expectation
+- Clear primary action text such as `Confirm claim all`
+- Secondary cancel action
+
+Confirmation rules:
+
+- Never trigger `Claim all` directly from the sticky bar with one tap.
+- Never use swipe, long-press, or gesture shortcuts for `Claim all`.
+- Do not place `Claim all` inside a crowded overflow menu with destructive items.
+- Disable the confirm button until claimable totals are loaded if the amount is still resolving.
+- If claiming is partially unavailable, explain what will be skipped before confirmation.
+- After confirmation, show progress and completion feedback without removing the user from the portfolio context.
+
+Passing pattern: tapping `Claim all` opens a confirmation sheet reading `Claim 12 positions` with total amount, fee note, cancel, and confirm actions.
+
+Failing pattern: tapping `Claim all` immediately submits the transaction or confirms with a generic `Are you sure?` message that hides the actual impact.
+
+## Thumb-Reach And Layout Guidance
+
+- Place the sticky bar at the bottom edge above the device safe area.
+- Keep the most common actions centered or bottom-right within easy thumb reach.
+- Avoid placing primary quick actions only in the top app bar on mobile.
+- Keep tap targets large enough for one-handed use, especially for filter chips and claim actions.
+- When the keyboard opens for search, keep filter and claim actions reachable after dismissing the keyboard.
+
+## Search, Filter, And Group Behavior
+
+### Search
+
+- Search should open inline in the bottom sheet or expand from the quick-actions bar.
+- Keep the field persistent until dismissed so users can refine results without re-opening actions.
+
+### Filter
+
+- Show active filter count in the closed state.
+- Group filters by meaning, such as status, token, settlement state, and date.
+- Provide clear reset and apply actions at the bottom of the sheet.
+
+### Group
+
+- Keep grouping options short and mutually exclusive.
+- Recommended groups for portfolio:
+  - Claimable first
+  - Status
+  - Market
+  - Token
+- If group order changes the list significantly, show the active grouping in the closed state.
+
+## Claimable-Heavy Portfolio Example
+
+Use this example when the user has many settled positions ready to claim.
+
+Closed state:
+
+- Sticky bar shows `Search`, `Filter`, `Group`, and `Claim all`.
+- The `Claim all` control includes a count badge such as `12`.
+
+Open state:
+
+- Bottom sheet header shows `Portfolio actions`.
+- Summary row states `12 positions ready to claim`.
+- Search and filter sections remain available above the claim section.
+- Claim section includes token totals and a short note such as `Some claims may settle in separate wallet prompts`.
+
+Confirmation state:
+
+- Confirmation sheet headline: `Claim all ready positions`
+- Body copy: shows count, estimated total, and any wallet or network note
+- Primary action: `Confirm claim all`
+- Secondary action: `Cancel`
+
+Failing example:
+
+- A claimable-heavy portfolio uses a single bright floating button over the list with no count, no summary, and no confirmation.
+
+## PR Review Evidence
+
+For mobile portfolio quick-action changes, include these screenshots in the PR:
+
+- 1 mobile screenshot with quick actions closed
+- 1 mobile screenshot with quick actions open
+- 1 mobile screenshot of the `Claim all` confirmation state when applicable
+- 1 mobile screenshot of a claimable-heavy portfolio example
+
+## Validation Against Existing Screens
+
+### `app/(dashboard)/mypredictions`
+
+- Opportunity: replace the top-right filter-only action with a thumb-reach quick-actions bar for search, filter, and group.
+- Risk to watch: the current top-area controls compete with the main tabs and are harder to reach one-handed on mobile.
+
+### `components/transactions/TransactionsHstory.tsx`
+
+- Opportunity: move dense filter controls into a bottom sheet and expose the active filter count from the sticky quick-actions bar.
+- Risk to watch: the current expanded filter panel takes large vertical space and would feel heavy on smaller screens.
+
+### Claimable-heavy portfolio state
+
+- Opportunity: use a count-aware `Claim all` entry point with a separate confirmation step and summary totals.
+- Risk to watch: placing `Claim all` beside low-risk discovery actions without separation makes accidental submission more likely.

--- a/DESIGN_STICKY_ACTION_PANEL.md
+++ b/DESIGN_STICKY_ACTION_PANEL.md
@@ -1,0 +1,253 @@
+# Sticky Action Panel For Market Detail
+
+This design spec defines how the market detail action panel should behave across desktop and mobile for betting, claiming, and dispute-related actions.
+
+Scope: frontend design only.
+Timeframe: apply this pattern to market detail work delivered within 96 hours before merge.
+
+## Goal
+
+Keep the primary action reachable without covering important market content. The sticky panel should adapt to market lifecycle state, remain usable with mobile keyboards, and never trap the user on small screens.
+
+## Preferred Pattern
+
+Use a responsive sticky action panel with different behavior by breakpoint:
+
+- Desktop: sticky right-side panel inside the market detail layout
+- Mobile: sticky bottom action panel with expandable details
+
+The panel must remain dismissible or collapsible when it risks covering content or competing with input focus.
+
+## Sticky Behavior Rules And Breakpoints
+
+### Desktop: `min-width: 1024px`
+
+- Place the action panel in the right rail beside the main market content.
+- Keep it sticky below the page header once the panel reaches the viewport top.
+- Do not let the sticky panel overlap the footer or extend beyond the main content container.
+- Keep the primary CTA visible without requiring the user to scroll back to the top of the market page.
+- Show supporting details in the panel by default: selected outcome, amount, payout summary, or claim/dispute context depending on state.
+
+Passing pattern: the main market content scrolls while the action panel remains pinned in the right rail with the primary CTA visible.
+
+Failing pattern: the panel covers market content, overlaps the footer, or sticks so aggressively that the user loses access to context below it.
+
+### Tablet: `640px - 1023px`
+
+- Use a stacked layout with the action panel following the main market summary.
+- The panel may become sticky only after the user scrolls past the market header.
+- Keep the sticky treatment lighter than desktop: pin the primary CTA row, not the full detail card, when vertical space is limited.
+- Collapse secondary details by default if the content would push the primary CTA below the fold.
+
+Passing pattern: the CTA row stays reachable while secondary payout or dispute details collapse into a summary line.
+
+Failing pattern: the entire action card remains fixed and covers the odds list, evidence section, or important market notes.
+
+### Mobile: `< 640px`
+
+- Use a bottom-anchored sticky action panel above the safe area.
+- Keep the closed state compact: summary plus primary CTA only.
+- Expand supporting details in a sheet, drawer, or inline expansion above the CTA row.
+- The panel must never permanently cover the bottom of the market content; reserve space or pad the page bottom so the final content remains readable.
+- Provide a visible collapse or dismiss affordance when the expanded panel is open.
+
+Passing pattern: the sticky bar shows selected state and primary CTA, while full details expand only when needed.
+
+Failing pattern: a large fixed panel blocks the final market options, the dispute rationale, or the last historical row.
+
+## Keyboard And Input Behavior On Mobile
+
+- When the amount field or textarea receives focus, the sticky panel should move above the on-screen keyboard or reduce to a compact CTA strip.
+- Never let the keyboard cover the input, helper text, or the primary CTA.
+- If the keyboard reduces usable height too far, collapse secondary panel details automatically and preserve only:
+  - Selected outcome or action label
+  - Primary input summary
+  - Primary CTA
+- If the user is entering a dispute reason or bet amount, do not trap focus inside the sticky panel.
+- The user must still be able to scroll the page content and dismiss the keyboard naturally.
+
+Passing pattern: focusing the bet amount field lifts or compacts the sticky panel so the field, helper text, and CTA remain visible above the keyboard.
+
+Failing pattern: the keyboard hides the amount field or submit button, or the sticky panel pins itself over the text entry area.
+
+## Dismissible And Collapsible Rules
+
+- The panel must be collapsible on mobile and tablet when expanded details are not actively needed.
+- Use a clear affordance such as `Show details`, chevron collapse, or drag handle.
+- Do not force the user to keep a tall panel open while reading market rules, history, or dispute evidence.
+- If the panel is dismissed, preserve a compact CTA stub so the primary action remains reachable.
+- Reopening the panel should restore the most recent input state where safe.
+
+Passing pattern: a user collapses the detail area and keeps a one-line sticky CTA bar visible while reading the rest of the page.
+
+Failing pattern: the sticky panel cannot be collapsed and occupies a fixed portion of the mobile viewport for the entire session.
+
+## Content By Market Lifecycle State
+
+The sticky panel content should change based on the market state instead of showing the same controls everywhere.
+
+### Active Market: Bet State
+
+Primary CTA:
+
+- `Place Bet`
+
+Panel content:
+
+- Selected outcome summary
+- Bet amount field
+- Potential payout summary
+- Fee or slippage note if relevant
+- Validation or success feedback near the CTA
+
+Rules:
+
+- Keep the amount field and primary CTA in the same visible area.
+- If no outcome is selected, use a disabled CTA with guidance such as `Select an outcome to continue`.
+- Do not hide payout feedback below the sticky boundary when the user is typing.
+
+Passing pattern: selected option, amount, payout, and `Place Bet` remain visible together in the sticky panel.
+
+Failing pattern: the CTA remains visible but the selected outcome or amount context scrolls out of view, forcing guesswork.
+
+### Closed Or Pending Resolution State
+
+Primary CTA:
+
+- No bet CTA
+- Optional informational CTA such as `View Resolution Rules` or `Track Outcome` only if useful
+
+Panel content:
+
+- Market status
+- Resolution countdown or pending status
+- Claim availability summary if not yet claimable
+- Dispute availability if the lifecycle permits it
+
+Rules:
+
+- Do not keep a disabled `Place Bet` CTA as the dominant action once the market closes.
+- Shift the panel from transaction-first to status-first content.
+
+### Resolved Claimable State
+
+Primary CTA:
+
+- `Claim Winnings` or `Claim Payout`
+
+Panel content:
+
+- Outcome summary
+- Claimable amount
+- Wallet or token summary
+- Fee note if relevant
+- Secondary action for dispute only if the dispute window is still valid
+
+Rules:
+
+- The claimable amount must be visible in the closed mobile state.
+- If the market is resolved and claimable, claiming should outrank betting or informational actions.
+- If multiple claims or wallet prompts are expected, state that before the CTA.
+
+Passing pattern: the sticky panel shows final outcome, claim amount, and a reachable `Claim Winnings` CTA.
+
+Failing pattern: the claim CTA is buried under non-essential market history, or the user must scroll back to the top to find it.
+
+### Dispute-Eligible State
+
+Primary CTA:
+
+- `Raise Dispute` only when the dispute window is open and the user is eligible
+
+Panel content:
+
+- Current resolution status
+- Dispute deadline
+- Warning text or stake requirement
+- Secondary access to claim only if claim and dispute can coexist in the same phase
+
+Rules:
+
+- Do not style dispute as the default action when claim is the main user path.
+- Keep dispute warnings visible without pushing the CTA below the fold.
+- Long evidence-entry flows should expand into a dedicated drawer or modal, not inside a permanently tall sticky panel.
+
+### Dispute Open Or Voting State
+
+Primary CTA:
+
+- State-specific action such as `Vote`, `Stake On Outcome`, or `View Dispute`
+
+Panel content:
+
+- Dispute state badge
+- Time remaining
+- Leading side or tally summary if available
+- Link or secondary action to full dispute details
+
+Rules:
+
+- Reduce market-betting content once the dispute process becomes the dominant state.
+- Keep the sticky panel focused on the next valid user action, not the entire dispute record.
+
+## Content Priority In Closed Mobile State
+
+The closed mobile sticky panel should show only:
+
+- Market state label
+- One short context line such as selected outcome, claim amount, or dispute timer
+- Primary CTA
+
+Do not include long descriptions, full historical data, or long evidence text in the closed state.
+
+## Space Protection Rules
+
+- Add bottom padding to the main market detail page equal to the closed sticky panel height plus safe-area spacing.
+- Increase reserved bottom spacing when the panel is expanded.
+- Do not allow the sticky panel to cover:
+  - Last betting option
+  - Last explanatory paragraph in market rules
+  - Last item in historical data
+  - Dispute warnings or evidence summary
+
+## Examples
+
+### Active State Example
+
+- Desktop: right-rail sticky card shows selected outcome, amount input, payout summary, and `Place Bet`.
+- Mobile closed: bottom bar shows selected outcome plus `Place Bet`.
+- Mobile expanded: amount field, payout summary, error/help text, and CTA appear above the keyboard-safe area.
+
+### Resolved Claimable State Example
+
+- Desktop: sticky right rail shows final outcome, claimable balance, wallet note, and `Claim Winnings`.
+- Mobile closed: bottom bar shows `Claimable: 42.50 USDC` plus `Claim Winnings`.
+- Mobile expanded: claim amount, token breakdown, wallet prompt note, and optional dispute-window notice.
+
+## PR Review Evidence
+
+For sticky action panel changes, include these screenshots in the PR:
+
+- 1 desktop screenshot with the sticky panel visible
+- 1 mobile screenshot with the panel closed
+- 1 mobile screenshot with the panel expanded
+- 1 mobile screenshot with the keyboard open while interacting with the panel
+- 1 screenshot for an active betting state
+- 1 screenshot for a resolved claimable state
+
+## Validation Against Existing Screens
+
+### `app/(dashboard)/events/event-page`
+
+- Opportunity: replace the current always-visible side card with a responsive sticky pattern that keeps the primary action reachable across desktop and mobile.
+- Risk to watch: the current bet form is separated from the option list, which can make context harder to preserve on smaller screens.
+
+### `components/patterns/BetConfirmPattern.tsx`
+
+- Opportunity: reuse the repo's existing desktop dialog and mobile drawer mental model for expanded action details and confirmation.
+- Risk to watch: confirmation flows should not replace the need for a reachable sticky primary CTA on the base market page.
+
+### `components/patterns/DisputeActionPattern.tsx`
+
+- Opportunity: treat long dispute evidence flows as expanded overlays triggered from the sticky panel rather than forcing everything into the persistent panel.
+- Risk to watch: dispute forms are long, so the sticky panel must hand off to a drawer or modal before the UI becomes cramped.

--- a/Design.md
+++ b/Design.md
@@ -1,11 +1,17 @@
-# Results & Payouts Page
+# Design References
+
+## Results & Payouts Page
 
 This design covers the Results & Payouts Page for Predictify, including:
 
-- Past bets list (event name, bet amount, outcome)
+- Past bets list with event name, bet amount, and outcome
 - Winning bet highlights and payout display
 - Platform fee deductions
 - Withdraw winnings button
 - Dark theme with clean layout
 
-👉 [View the design in Figma](https://www.figma.com/design/MniUXvhhw8zByH1tTF416Q/Predictify?node-id=1-2&t=5srcb0bfBWs0Xdmn-1)
+[View the design in Figma](https://www.figma.com/design/MniUXvhhw8zByH1tTF416Q/Predictify?node-id=1-2&t=5srcb0bfBWs0Xdmn-1)
+
+## Review Checklist
+
+Use [DESIGN_ACCESSIBILITY_CHECKLIST.md](./DESIGN_ACCESSIBILITY_CHECKLIST.md) for screen-level accessibility review during design work and UI PR review.

--- a/Design.md
+++ b/Design.md
@@ -15,3 +15,7 @@ This design covers the Results & Payouts Page for Predictify, including:
 ## Review Checklist
 
 Use [DESIGN_ACCESSIBILITY_CHECKLIST.md](./DESIGN_ACCESSIBILITY_CHECKLIST.md) for screen-level accessibility review during design work and UI PR review.
+
+## Mobile Portfolio Actions
+
+Use [DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md](./DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md) for mobile quick-action placement, confirmation rules, and PR evidence on portfolio screens.

--- a/Design.md
+++ b/Design.md
@@ -19,3 +19,7 @@ Use [DESIGN_ACCESSIBILITY_CHECKLIST.md](./DESIGN_ACCESSIBILITY_CHECKLIST.md) for
 ## Mobile Portfolio Actions
 
 Use [DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md](./DESIGN_MOBILE_PORTFOLIO_QUICK_ACTIONS.md) for mobile quick-action placement, confirmation rules, and PR evidence on portfolio screens.
+
+## Sticky Action Panels
+
+Use [DESIGN_STICKY_ACTION_PANEL.md](./DESIGN_STICKY_ACTION_PANEL.md) for market-detail sticky CTA behavior, lifecycle content, and mobile keyboard guidance.


### PR DESCRIPTION
This PR adds a design spec for a sticky action panel on market detail screens, defining how bet, claim, and dispute actions should stay reachable across desktop, tablet, and mobile without covering important content. The guidance introduces breakpoint-specific behaviour for a sticky right-rail panel on desktop and a compact, expandable bottom action panel on mobile, includes rules for keyboard-open behaviour and safe-area spacing, and requires the panel to be dismissible or collapsible so it never traps users on small screens. It also maps panel content to market lifecycle states such as active betting, closed or pending resolution, resolved claimable, and dispute phases, provides concrete examples for active and resolved claimable states, and updates PR review guidance to require screenshots for desktop, mobile closed and expanded states, and the mobile keyboard-open case.
closes #166 