### PR TITLE
feat(design): moderation banners and market status badges

### DIFF
--- a/app/(dashboard)/moderation-demo/page.tsx
+++ b/app/(dashboard)/moderation-demo/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { ModerationBanner } from '@/components/moderation/ModerationBanner';
+import { MarketStatusBadge } from '@/components/moderation/MarketStatusBadge';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { ModerationState } from '@/types/moderation';
+
+const STATES: ModerationState[] = ['under_review', 'paused', 'restricted', 'flagged', 'removed'];
+
+// Simulated market list card
+function MockMarketCard({ title, category, state }: { title: string; category: string; state?: ModerationState }) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1 flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-sm leading-tight truncate">{title}</span>
+            {state && <MarketStatusBadge state={state} />}
+          </div>
+          <Badge className="bg-[#EBE7F6] text-[#4400FF] border-0 text-xs">{category}</Badge>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-xs text-muted-foreground">Odds</div>
+          <div className="font-bold text-sm">1.85</div>
+        </div>
+      </div>
+      <div className="w-full bg-muted/50 rounded-full h-1.5">
+        <div className="h-full rounded-full bg-primary/60 w-[62%]" />
+      </div>
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>1,240 participants</span>
+        <span>3d 14h remaining</span>
+      </div>
+    </div>
+  );
+}
+
+export default function ModerationDemoPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4 space-y-12">
+      <div>
+        <h1 className="text-h3 font-bold mb-1">Moderation Banners</h1>
+        <p className="text-muted-foreground text-sm">
+          Design system reference for market moderation states — banners (detail page) and badges (list cards).
+        </p>
+      </div>
+
+      {/* ── Detail page banners ── */}
+      <section className="space-y-4">
+        <h2 className="text-h5 font-semibold">Detail Page Banners</h2>
+        <p className="text-sm text-muted-foreground">
+          Placed at the top of a market detail page, above the trading interface.
+        </p>
+        <div className="space-y-3">
+          {STATES.map((state) => (
+            <ModerationBanner key={state} state={state} />
+          ))}
+        </div>
+      </section>
+
+      {/* ── List card badges ── */}
+      <section className="space-y-4">
+        <h2 className="text-h5 font-semibold">Market List Card Badges</h2>
+        <p className="text-sm text-muted-foreground">
+          Compact inline badges shown on market list cards. Hover for tooltip.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          {STATES.map((state) => (
+            <MarketStatusBadge key={state} state={state} />
+          ))}
+        </div>
+      </section>
+
+      {/* ── Market cards with badges ── */}
+      <section className="space-y-4">
+        <h2 className="text-h5 font-semibold">Market Cards — In Context</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <MockMarketCard title="Will BTC reach $100k by Q3?" category="Crypto" />
+          <MockMarketCard title="Champions League Final Winner" category="Football" state="under_review" />
+          <MockMarketCard title="US Election 2026 Senate Majority" category="Politics" state="paused" />
+          <MockMarketCard title="AAPL Q2 Earnings Beat?" category="Stocks" state="restricted" />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/moderation/MarketStatusBadge.tsx
+++ b/components/moderation/MarketStatusBadge.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Clock, AlertTriangle, ShieldAlert, Flag, XCircle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import type { ModerationState } from '@/types/moderation';
+import { MODERATION_CONFIG } from './moderation-config';
+
+const STATE_ICONS: Record<ModerationState, React.ElementType> = {
+  under_review: Clock,
+  paused: AlertTriangle,
+  restricted: ShieldAlert,
+  flagged: Flag,
+  removed: XCircle,
+};
+
+interface MarketStatusBadgeProps {
+  state: ModerationState;
+  className?: string;
+  /** Show tooltip with short description on hover */
+  showTooltip?: boolean;
+}
+
+export function MarketStatusBadge({ state, className, showTooltip = true }: MarketStatusBadgeProps) {
+  const config = MODERATION_CONFIG[state];
+  const Icon = STATE_ICONS[state];
+
+  const badge = (
+    <span
+      role="status"
+      aria-label={`Market status: ${config.label}`}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold',
+        config.badgeClass,
+        className
+      )}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      {config.label}
+    </span>
+  );
+
+  if (!showTooltip) return badge;
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>{badge}</TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[220px] text-xs">
+          <p>{config.description}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/moderation/ModerationBanner.tsx
+++ b/components/moderation/ModerationBanner.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { AlertTriangle, Clock, ShieldAlert, Flag, XCircle } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
+import type { ModerationState } from '@/types/moderation';
+import { MODERATION_CONFIG } from './moderation-config';
+
+const STATE_ICONS: Record<ModerationState, React.ElementType> = {
+  under_review: Clock,
+  paused: AlertTriangle,
+  restricted: ShieldAlert,
+  flagged: Flag,
+  removed: XCircle,
+};
+
+interface ModerationBannerProps {
+  state: ModerationState;
+  className?: string;
+  /** Override the default "learn more" href */
+  learnMoreHref?: string;
+}
+
+export function ModerationBanner({ state, className, learnMoreHref }: ModerationBannerProps) {
+  const config = MODERATION_CONFIG[state];
+  const Icon = STATE_ICONS[state];
+  const href = learnMoreHref ?? config.learnMoreHref;
+
+  return (
+    <Alert
+      role="status"
+      aria-label={`Market status: ${config.label}`}
+      className={cn(config.bannerClass, 'flex flex-col gap-1', className)}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle className="font-semibold">{config.title}</AlertTitle>
+      <AlertDescription className="space-y-1">
+        <p>{config.description}</p>
+        <p className="font-medium">{config.allowedActions}</p>
+        <a
+          href={href}
+          className="inline-flex items-center gap-1 text-sm underline underline-offset-2 opacity-80 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-current focus:ring-offset-1 rounded"
+          aria-label={`Learn more about ${config.label} status`}
+        >
+          Learn more →
+        </a>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/components/moderation/index.ts
+++ b/components/moderation/index.ts
@@ -1,0 +1,4 @@
+export { ModerationBanner } from './ModerationBanner';
+export { MarketStatusBadge } from './MarketStatusBadge';
+export { MODERATION_CONFIG } from './moderation-config';
+export type { ModerationState, ModerationConfig } from '@/types/moderation';

--- a/components/moderation/moderation-config.ts
+++ b/components/moderation/moderation-config.ts
@@ -1,0 +1,54 @@
+import type { ModerationConfig, ModerationState } from '@/types/moderation';
+
+export const MODERATION_CONFIG: Record<ModerationState, ModerationConfig> = {
+  under_review: {
+    label: 'Under Review',
+    title: 'This market is currently under review.',
+    description: 'Our team is verifying this market to ensure it meets community guidelines.',
+    allowedActions: 'Trading remains available during this review.',
+    learnMoreHref: '/help/moderation#under-review',
+    bannerClass:
+      'border-amber-400/50 bg-amber-50 text-amber-900 dark:bg-amber-950/20 dark:text-amber-300 [&>svg]:text-amber-500',
+    badgeClass: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  paused: {
+    label: 'Paused',
+    title: 'This market is temporarily paused.',
+    description: 'Activity on this market has been suspended while we investigate a reported issue.',
+    allowedActions: 'New actions are temporarily disabled. Existing positions are unaffected.',
+    learnMoreHref: '/help/moderation#paused',
+    bannerClass:
+      'border-orange-400/50 bg-orange-50 text-orange-900 dark:bg-orange-950/20 dark:text-orange-300 [&>svg]:text-orange-500',
+    badgeClass: 'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-900/30 dark:text-orange-300',
+  },
+  restricted: {
+    label: 'Restricted',
+    title: 'This market has restricted access.',
+    description: 'Participation in this market is limited to eligible users based on regional or compliance rules.',
+    allowedActions: 'View-only access is available. Trading may be unavailable in your region.',
+    learnMoreHref: '/help/moderation#restricted',
+    bannerClass:
+      'border-slate-400/50 bg-slate-50 text-slate-900 dark:bg-slate-950/20 dark:text-slate-300 [&>svg]:text-slate-500',
+    badgeClass: 'bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-800/50 dark:text-slate-300',
+  },
+  flagged: {
+    label: 'Flagged',
+    title: 'This market has been flagged for review.',
+    description: 'Community members have raised concerns about this market. Our team is investigating.',
+    allowedActions: 'Trading is paused until the review is complete.',
+    learnMoreHref: '/help/moderation#flagged',
+    bannerClass:
+      'border-red-400/50 bg-red-50 text-red-900 dark:bg-red-950/20 dark:text-red-300 [&>svg]:text-red-500',
+    badgeClass: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900/30 dark:text-red-300',
+  },
+  removed: {
+    label: 'Removed',
+    title: 'This market has been removed.',
+    description: 'This market was found to violate community guidelines and has been permanently closed.',
+    allowedActions: 'No further actions are available on this market.',
+    learnMoreHref: '/help/moderation#removed',
+    bannerClass:
+      'border-red-600/50 bg-red-100 text-red-950 dark:bg-red-950/30 dark:text-red-200 [&>svg]:text-red-600',
+    badgeClass: 'bg-red-200 text-red-900 border-red-400 dark:bg-red-900/40 dark:text-red-200',
+  },
+};

--- a/types/moderation.ts
+++ b/types/moderation.ts
@@ -1,0 +1,14 @@
+// Moderation state vocabulary — extensible for future states
+export type ModerationState = 'under_review' | 'paused' | 'restricted' | 'flagged' | 'removed';
+
+export interface ModerationConfig {
+  label: string;
+  title: string;
+  description: string;
+  allowedActions: string;
+  learnMoreHref: string;
+  /** Tailwind classes for banner background + text + border */
+  bannerClass: string;
+  /** Tailwind classes for badge background + text */
+  badgeClass: string;
+}


### PR DESCRIPTION
closes #163 

Adds reusable UI components for communicating market moderation states to users.

- ModerationBanner — full-width banner for market detail pages (Under Review, Paused, Restricted, Flagged, Removed)
- MarketStatusBadge — compact inline badge with tooltip for market list cards
- Config-driven design: all copy, colors, and learn-more links live in one file for easy extension
- Demo page available at /moderation-demo

All states include clear messaging on what the status means and what actions are still allowed.
