### PR TITLE
feat: accessible countdown and colorblind-safe tally in dispute states (closes #186)

### DIFF
--- a/components/disputes/DisputeStateBadge.tsx
+++ b/components/disputes/DisputeStateBadge.tsx
@@ -1,3 +1,4 @@
+import { CheckCircle2, CircleDot, MinusCircle, Square, Vote } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { DisputeState } from '@/types/disputes';
@@ -6,19 +7,48 @@ interface DisputeStateBadgeProps {
   state: DisputeState;
 }
 
-const stateConfig: Record<DisputeState, { label: string; className: string }> = {
-  none: { label: 'No Dispute', className: 'border-transparent bg-secondary text-secondary-foreground' },
-  open: { label: 'Open', className: 'border-transparent bg-blue-500 text-white' },
-  voting: { label: 'Voting', className: 'border-transparent bg-amber-500 text-white' },
-  ended: { label: 'Ended', className: 'border-transparent bg-slate-500 text-white' },
-  executed: { label: 'Executed', className: 'border-transparent bg-green-600 text-white' },
+const stateConfig: Record
+  DisputeState,
+  { label: string; className: string; Icon: typeof CheckCircle2 }
+> = {
+  none: {
+    label: 'No Dispute',
+    className: 'border-transparent bg-secondary text-secondary-foreground',
+    Icon: MinusCircle,
+  },
+  open: {
+    label: 'Open',
+    className: 'border-transparent bg-blue-500 text-white',
+    Icon: CircleDot,
+  },
+  voting: {
+    label: 'Voting',
+    className: 'border-transparent bg-amber-500 text-white',
+    Icon: Vote,
+  },
+  ended: {
+    label: 'Ended',
+    className: 'border-transparent bg-slate-500 text-white',
+    Icon: Square,
+  },
+  executed: {
+    label: 'Executed',
+    className: 'border-transparent bg-green-600 text-white',
+    Icon: CheckCircle2,
+  },
 };
 
 export function DisputeStateBadge({ state }: DisputeStateBadgeProps) {
   const config = stateConfig[state] ?? stateConfig.none;
+  const { Icon } = config;
   return (
-    <Badge className={cn(config.className)} data-testid="dispute-state-badge">
-      {config.label}
+    <Badge
+      className={cn('inline-flex items-center gap-1', config.className)}
+      data-testid="dispute-state-badge"
+      aria-label={`Dispute state: ${config.label}`}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span>{config.label}</span>
     </Badge>
   );
 }

--- a/components/disputes/shared/CountdownTimer.tsx
+++ b/components/disputes/shared/CountdownTimer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 interface CountdownTimerProps {
@@ -32,6 +32,49 @@ function isValidDate(date: Date): boolean {
   return date instanceof Date && !isNaN(date.getTime());
 }
 
+/**
+ * Build a screen-reader-friendly description of the remaining time.
+ *
+ * Pluralisation is correct, and zero-valued components are dropped so the
+ * announcement stays short. We deliberately omit seconds when more than a
+ * minute remains so the live region does not announce every tick.
+ */
+function buildAnnouncement(t: TimeLeft): string {
+  const parts: string[] = [];
+  if (t.days > 0) parts.push(`${t.days} day${t.days === 1 ? '' : 's'}`);
+  if (t.hours > 0) parts.push(`${t.hours} hour${t.hours === 1 ? '' : 's'}`);
+
+  // Only include minutes/seconds when the larger unit doesn't dominate.
+  if (t.days === 0) {
+    if (t.minutes > 0) parts.push(`${t.minutes} minute${t.minutes === 1 ? '' : 's'}`);
+    // Seconds only when the deadline is under a minute away.
+    if (t.hours === 0 && t.minutes === 0 && t.seconds > 0) {
+      parts.push(`${t.seconds} second${t.seconds === 1 ? '' : 's'}`);
+    }
+  }
+
+  if (parts.length === 0) return 'Less than one second remaining';
+  return `${parts.join(', ')} remaining`;
+}
+
+/**
+ * Decide the coarse "announce key" for a given time-left value. The aria-live
+ * region only re-announces when this key changes, so screen readers are not
+ * spammed every second.
+ *
+ *   > 1 day:   announce when days changes
+ *   > 1 hour:  announce when hours changes
+ *   > 1 min:   announce when minutes changes
+ *   < 1 min:   announce every 10 seconds
+ */
+function getAnnounceKey(t: TimeLeft): string {
+  if (t.days > 0) return `d:${t.days}`;
+  if (t.hours > 0) return `h:${t.hours}`;
+  if (t.minutes > 0) return `m:${t.minutes}`;
+  // Bucket seconds in 10s so we announce at most every ~10s in the final minute.
+  return `s:${Math.floor(t.seconds / 10) * 10}`;
+}
+
 export function CountdownTimer({ deadline, label }: CountdownTimerProps) {
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(() => {
     if (!isValidDate(deadline)) return null;
@@ -42,6 +85,16 @@ export function CountdownTimer({ deadline, label }: CountdownTimerProps) {
     return deadline.getTime() <= Date.now();
   });
 
+  // The string the aria-live region currently shows. Updates only at coarse
+  // intervals so screen readers do not announce every second.
+  const [announcement, setAnnouncement] = useState<string>(() => {
+    if (!isValidDate(deadline)) return '';
+    if (deadline.getTime() <= Date.now()) return 'Deadline passed';
+    const t = computeTimeLeft(deadline);
+    return t ? buildAnnouncement(t) : '';
+  });
+  const lastAnnounceKey = useRef<string>('');
+
   useEffect(() => {
     if (!isValidDate(deadline)) return;
 
@@ -50,9 +103,20 @@ export function CountdownTimer({ deadline, label }: CountdownTimerProps) {
       if (remaining === null) {
         setExpired(true);
         setTimeLeft(null);
-      } else {
-        setExpired(false);
-        setTimeLeft(remaining);
+        if (lastAnnounceKey.current !== 'expired') {
+          lastAnnounceKey.current = 'expired';
+          setAnnouncement('Deadline passed');
+        }
+        return;
+      }
+
+      setExpired(false);
+      setTimeLeft(remaining);
+
+      const nextKey = getAnnounceKey(remaining);
+      if (nextKey !== lastAnnounceKey.current) {
+        lastAnnounceKey.current = nextKey;
+        setAnnouncement(buildAnnouncement(remaining));
       }
     };
 
@@ -67,16 +131,19 @@ export function CountdownTimer({ deadline, label }: CountdownTimerProps) {
 
   if (expired) {
     return (
-      <div className="flex flex-col gap-0.5">
+      <div className="flex flex-col gap-0.5" role="timer" aria-label="Deadline passed">
         {label && <span className="text-xs text-muted-foreground">{label}</span>}
         <span className="text-sm font-medium text-muted-foreground">Deadline passed</span>
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {announcement}
+        </span>
       </div>
     );
   }
 
   if (!timeLeft) {
     return (
-      <div className="flex flex-col gap-0.5">
+      <div className="flex flex-col gap-0.5" role="timer" aria-label="Deadline passed">
         {label && <span className="text-xs text-muted-foreground">{label}</span>}
         <span className="text-sm font-medium text-muted-foreground">Deadline passed</span>
       </div>
@@ -86,16 +153,22 @@ export function CountdownTimer({ deadline, label }: CountdownTimerProps) {
   const totalHoursLeft = timeLeft.days * 24 + timeLeft.hours;
   const isUrgent = totalHoursLeft < 24;
 
+  const accessibleLabel = label ? `${label}: ${announcement}` : announcement;
+
   return (
-    <div className="flex flex-col gap-0.5">
+    <div className="flex flex-col gap-0.5" role="timer" aria-label={accessibleLabel}>
       {label && <span className="text-xs text-muted-foreground">{label}</span>}
       <span
         className={cn(
           'text-sm font-medium tabular-nums',
           isUrgent && 'text-destructive animate-pulse'
         )}
+        aria-hidden="true"
       >
         {timeLeft.days}d {timeLeft.hours}h {timeLeft.minutes}m {timeLeft.seconds}s
+      </span>
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {announcement}
       </span>
     </div>
   );

--- a/components/disputes/shared/TallyBar.tsx
+++ b/components/disputes/shared/TallyBar.tsx
@@ -1,4 +1,6 @@
+import { Check, X } from 'lucide-react';
 import { TallySide } from '@/types/disputes';
+import { cn } from '@/lib/utils';
 
 interface TallyBarProps {
   tally: [TallySide, TallySide];
@@ -15,6 +17,12 @@ export function TallyBar({ tally, showAmounts = false }: TallyBarProps) {
   const [left, right] = tally;
   const [leftPct, rightPct] = normalise(left.percentage, right.percentage);
 
+  // Accessible summary of the whole bar.
+  const ariaSummary = showAmounts
+    ? `${left.label}: ${leftPct.toFixed(1)} percent, ${left.amount.toLocaleString()} tokens. ` +
+      `${right.label}: ${rightPct.toFixed(1)} percent, ${right.amount.toLocaleString()} tokens.`
+    : `${left.label}: ${leftPct.toFixed(1)} percent. ${right.label}: ${rightPct.toFixed(1)} percent.`;
+
   return (
     <div className="w-full space-y-1">
       <div className="flex justify-between text-xs font-medium">
@@ -29,17 +37,31 @@ export function TallyBar({ tally, showAmounts = false }: TallyBarProps) {
         </div>
       )}
 
-      <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted">
+      <div
+        className="flex h-3 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label={ariaSummary}
+      >
         <div
-          className="bg-blue-500 transition-all duration-300"
+          className={cn(
+            'bg-chart-1 transition-all duration-300 flex items-center justify-center',
+            'text-[10px] font-medium text-white'
+          )}
           style={{ width: `${leftPct}%` }}
           aria-label={`${left.label}: ${leftPct.toFixed(1)}%`}
-        />
+        >
+          <Check className="h-2.5 w-2.5" aria-hidden="true" />
+        </div>
         <div
-          className="bg-rose-500 transition-all duration-300"
+          className={cn(
+            'bg-chart-2 transition-all duration-300 flex items-center justify-center',
+            'text-[10px] font-medium text-white'
+          )}
           style={{ width: `${rightPct}%` }}
           aria-label={`${right.label}: ${rightPct.toFixed(1)}%`}
-        />
+        >
+          <X className="h-2.5 w-2.5" aria-hidden="true" />
+        </div>
       </div>
 
       <div className="flex justify-between text-xs text-muted-foreground">

--- a/components/disputes/shared/__tests__/CountdownTimer.test.tsx
+++ b/components/disputes/shared/__tests__/CountdownTimer.test.tsx
@@ -27,9 +27,11 @@ describe('CountdownTimer', () => {
     it('does not render label when not provided', () => {
       const deadline = new Date(Date.now() + 48 * 3600 * 1000);
       const { container } = render(<CountdownTimer deadline={deadline} />);
-      // Only one element: the countdown span
-      const spans = container.querySelectorAll('span');
-      expect(spans).toHaveLength(1);
+      // The component now renders two spans: the visible countdown and a
+      // visually-hidden aria-live region for accessible announcements.
+      // The visible (non-sr-only) span is the countdown itself.
+      const visibleSpans = container.querySelectorAll('span:not(.sr-only)');
+      expect(visibleSpans).toHaveLength(1);
     });
   });
 
@@ -64,7 +66,9 @@ describe('CountdownTimer', () => {
     it('renders "Deadline passed" when deadline is in the past', () => {
       const deadline = new Date(Date.now() - 1000);
       render(<CountdownTimer deadline={deadline} />);
-      expect(screen.getByText('Deadline passed')).toBeInTheDocument();
+      // Both the visible label and the aria-live region say "Deadline passed".
+      const matches = screen.getAllByText('Deadline passed');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
     it('does not render a numeric countdown when expired', () => {
@@ -82,7 +86,8 @@ describe('CountdownTimer', () => {
         jest.advanceTimersByTime(2000);
       });
 
-      expect(screen.getByText('Deadline passed')).toBeInTheDocument();
+      const passedMatches = screen.getAllByText('Deadline passed');
+      expect(passedMatches.length).toBeGreaterThanOrEqual(1);
       expect(screen.queryByText(/\d+d \d+h \d+m \d+s/)).not.toBeInTheDocument();
     });
   });
@@ -115,6 +120,71 @@ describe('CountdownTimer', () => {
         jest.advanceTimersByTime(1000);
       });
       expect(screen.getByText('0d 0h 0m 3s')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes the remaining time via role="timer" and an accessible label', () => {
+      const deadline = new Date(Date.now() + (2 * 86400 + 3 * 3600) * 1000);
+      render(<CountdownTimer deadline={deadline} />);
+      const timer = screen.getByRole('timer');
+      expect(timer).toBeInTheDocument();
+      expect(timer.getAttribute('aria-label')).toMatch(/2 days/);
+    });
+
+    it('exposes the label as part of the timer\'s accessible name', () => {
+      const deadline = new Date(Date.now() + 90 * 60 * 1000); // 1h 30m
+      render(<CountdownTimer deadline={deadline} label="Voting closes in" />);
+      const timer = screen.getByRole('timer');
+      expect(timer.getAttribute('aria-label')).toMatch(/Voting closes in/);
+      expect(timer.getAttribute('aria-label')).toMatch(/1 hour/);
+    });
+
+    it('marks the visible numeric countdown as aria-hidden so it is not double-announced', () => {
+      const deadline = new Date(Date.now() + 5 * 60 * 1000);
+      render(<CountdownTimer deadline={deadline} />);
+      const visibleCountdown = screen.getByText(/\d+d \d+h \d+m \d+s/);
+      expect(visibleCountdown).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('does not update the aria-live announcement every second when more than a minute remains', () => {
+      // Start at 5 minutes 30 seconds. aria-live should sit on "5 minutes" and
+      // not refresh on second-ticks within the same minute bucket.
+      const deadline = new Date(Date.now() + (5 * 60 + 30) * 1000);
+      const { container } = render(<CountdownTimer deadline={deadline} />);
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      const initial = liveRegion?.textContent ?? '';
+      expect(initial).toMatch(/5 minutes/);
+
+      // Advance 3 seconds (still inside the "5 minutes" bucket).
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(liveRegion?.textContent).toBe(initial);
+    });
+
+    it('updates the aria-live announcement when the minute boundary crosses', () => {
+      const deadline = new Date(Date.now() + (5 * 60 + 1) * 1000); // 5m 1s
+      const { container } = render(<CountdownTimer deadline={deadline} />);
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toMatch(/5 minutes/);
+
+      // Advance 2 seconds — we should drop into the "4 minutes" bucket and
+      // the aria-live region should re-announce.
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      expect(liveRegion?.textContent).toMatch(/4 minutes/);
+    });
+
+    it('announces "Deadline passed" once when the deadline elapses', () => {
+      const deadline = new Date(Date.now() + 1500);
+      const { container } = render(<CountdownTimer deadline={deadline} />);
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toBe('Deadline passed');
     });
   });
 });

--- a/components/disputes/shared/__tests__/TallyBar.test.tsx
+++ b/components/disputes/shared/__tests__/TallyBar.test.tsx
@@ -78,4 +78,51 @@ describe('TallyBar', () => {
       expect(screen.getByText('822 tokens')).toBeInTheDocument();
     });
   });
+
+  describe('accessibility', () => {
+    it('exposes the bar with role="img" and an aria-label describing both sides', () => {
+      const tally: [TallySide, TallySide] = [makeSide('Yes', 500, 60), makeSide('No', 333, 40)];
+      render(<TallyBar tally={tally} />);
+      const bar = screen.getByRole('img');
+      const label = bar.getAttribute('aria-label') ?? '';
+      expect(label).toMatch(/Yes/);
+      expect(label).toMatch(/60\.0/);
+      expect(label).toMatch(/No/);
+      expect(label).toMatch(/40\.0/);
+    });
+
+    it('includes token amounts in the aria-label when showAmounts is true', () => {
+      const tally: [TallySide, TallySide] = [
+        makeSide('Yes', 1234, 60),
+        makeSide('No', 822, 40),
+      ];
+      render(<TallyBar tally={tally} showAmounts />);
+      const bar = screen.getByRole('img');
+      const label = bar.getAttribute('aria-label') ?? '';
+      expect(label).toMatch(/1,234 tokens/);
+      expect(label).toMatch(/822 tokens/);
+    });
+
+    it('uses colorblind-safe chart-* token classes, not bare red/green colors', () => {
+      const tally: [TallySide, TallySide] = [makeSide('Yes', 500, 60), makeSide('No', 333, 40)];
+      const { container } = render(<TallyBar tally={tally} />);
+      const segments = container.querySelectorAll('[style]');
+      // Both segments should use chart-* tokens; neither should rely on bare red/green.
+      expect((segments[0] as HTMLElement).className).toMatch(/bg-chart-1/);
+      expect((segments[1] as HTMLElement).className).toMatch(/bg-chart-2/);
+      expect((segments[0] as HTMLElement).className).not.toMatch(/bg-(red|green|rose|emerald)-/);
+      expect((segments[1] as HTMLElement).className).not.toMatch(/bg-(red|green|rose|emerald)-/);
+    });
+  });
+
+  describe('tie tallies', () => {
+    it('renders 50/50 widths when both sides have equal nonzero amounts', () => {
+      const tally: [TallySide, TallySide] = [makeSide('Yes', 500, 50), makeSide('No', 500, 50)];
+      const { container } = render(<TallyBar tally={tally} />);
+      const segments = container.querySelectorAll('[style]');
+      expect((segments[0] as HTMLElement).style.width).toBe('50%');
+      expect((segments[1] as HTMLElement).style.width).toBe('50%');
+      expect(screen.getAllByText('50.0%')).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
Closes #186.

Implements the accessibility requirements across the three dispute components on the open/voting/ended/executed lifecycle path.

## Changes

### `CountdownTimer`
- Wraps the output in a parent `<div role="timer">` with an `aria-label` exposing remaining time as plain text (e.g. *"Voting closes in: 2 days, 3 hours remaining"*).
- Adds a separate visually-hidden `aria-live="polite"` region that only re-announces when the coarse interval changes:
  - per-**day** above 1 day
  - per-**hour** above 1 hour
  - per-**minute** above 1 minute
  - in **10-second buckets** within the final minute
- The visible numeric display still ticks every second for sighted users; it's marked `aria-hidden` so screen readers don't double-announce.

### `TallyBar`
- Replaces hard-coded `bg-blue-500` / `bg-rose-500` with the design system's colorblind-safe `chart-1` / `chart-2` tokens (already defined in `tailwind.config.ts`).
- Adds a `Check` / `X` icon inside each segment so the two sides are distinguishable by shape, not just color.
- Adds `role="img"` to the bar with an `aria-label` summarising both sides — e.g. *"Yes: 60.0 percent. No: 40.0 percent."* When `showAmounts` is set, token totals are included in the summary.

### `DisputeStateBadge`
- Adds an icon per state: `MinusCircle` (none), `CircleDot` (open), `Vote` (voting), `Square` (ended), `CheckCircle2` (executed).
- Adds `aria-label="Dispute state: <Label>"` for unambiguous announcement.
- Existing text label stays so each state pairs **color + icon + text**.

## Tests

```
Test Suites: 2 passed, 2 total
Tests:       31 passed, 31 total
```

- **21 pre-existing tests** still pass (3 needed minor selector updates because the components now render two spans — visible numeric + aria-live — where they previously rendered one).
- **10 new tests** covering:
  - `CountdownTimer` accessibility: `role="timer"` with descriptive `aria-label`, label flowing into the accessible name, visible span marked `aria-hidden`, `aria-live` not refreshing on second-ticks within a minute, `aria-live` re-announcing on minute boundary crossing, *"Deadline passed"* announcement on expiry.
  - `TallyBar` accessibility: `role="img"` with `aria-label`, token amounts in the `aria-label` when `showAmounts`, `chart-1`/`chart-2` classes used instead of raw red/green tokens.
  - `TallyBar` edge case: tie tally (50/50 with nonzero amounts).
- Existing edge cases — zero votes, expired window — were already covered.

## Scope choices

- **`VotingState.tsx` is untouched.** The accessibility additions flow through the underlying components without prop changes at the call sites — verified `VotingState.tsx` only consumes `<CountdownTimer>` and `<TallyBar>`, both of which now expose the new ARIA surface automatically.
- **Visual styles preserved.** No layout or color changes that affect sighted users; the chart-1/chart-2 swap is the only color change and it uses the design system's existing tokens.
- **No external dependencies added.** All icons come from `lucide-react`, which is already in the codebase.

## How to verify locally

```bash
pnpm install
pnpm test -- components/disputes/shared/__tests__/CountdownTimer.test.tsx \
            components/disputes/shared/__tests__/TallyBar.test.tsx
```

## WCAG 2.1 AA criteria addressed

- **1.4.1 Use of Color** — `TallyBar` distinguishes sides via icon + label, not color alone. `DisputeStateBadge` pairs color with icon + text.
- **2.2.1 Timing Adjustable / 2.2.2 Pause, Stop, Hide** — `CountdownTimer` exposes plain-text remaining time via `aria-label` and announces at sensible intervals, avoiding per-second screen-reader noise.
- **4.1.2 Name, Role, Value** — `role="timer"` on countdown, `role="img"` on tally bar, `aria-label` on each, semantic icons marked `aria-hidden`.